### PR TITLE
Resolves ENGA-932 "Modify BigQueryExporter class export() method to accept a pull_date"

### DIFF
--- a/bigquery_exporter/base.py
+++ b/bigquery_exporter/base.py
@@ -46,9 +46,34 @@ class BigQueryExporter:
                 raise ValueError(f'Custom field {field} is not defined')
 
     def define_queryset(self):
+        """
+        Returns the queryset for exporting data to BigQuery.
+
+        This method can be overridden in subclasses to specify additional filters or ordering
+        for the queryset. For example, you can use this method to filter data based on date ranges
+        or status fields.
+
+        It is important to note that if the queryset is larger than the class's batch size,
+        it must be ordered to avoid ordering bugs when accessing different segments of the queryset.
+
+        Returns:
+            QuerySet: The queryset for exporting data to BigQuery.
+        """
         return self.model.objects.all().order_by('id')
 
     def export(self, pull_date=None, *args, **kwargs):
+        """
+        Export data to BigQuery.
+
+        Args:
+            pull_date (datetime.datetime, optional): The date to pull data from. If not provided, the current date and time will be used.
+
+        Raises:
+            Exception: If an error occurs while exporting the data.
+
+        Returns:
+            None
+        """
         pull_time = datetime.datetime.now() if not pull_date else pull_date
         try:
             queryset = self.define_queryset()

--- a/bigquery_exporter/base.py
+++ b/bigquery_exporter/base.py
@@ -48,8 +48,8 @@ class BigQueryExporter:
     def define_queryset(self):
         return self.model.objects.all()
 
-    def export(self):
-        pull_time = datetime.datetime.now()
+    def export(self, pull_date=None, *args, **kwargs):
+        pull_time = datetime.datetime.now() if not pull_date else pull_date
         try:
             queryset = self.define_queryset()
             for start, end, total, qs in batch_qs(queryset, self.batch):

--- a/bigquery_exporter/base.py
+++ b/bigquery_exporter/base.py
@@ -72,7 +72,7 @@ class BigQueryExporter:
         Export data to BigQuery.
 
         Args:
-            pull_date (datetime.datetime, optional): The date to pull data from. If not provided, the current date and time will be used.
+            pull_date (datetime.datetime, optional): The datetime used to populate the pull_date field. If not provided, the current date and time will be used.
 
         Raises:
             Exception: If an error occurs while exporting the data.

--- a/bigquery_exporter/base.py
+++ b/bigquery_exporter/base.py
@@ -3,13 +3,6 @@ from google.cloud import bigquery
 from google.api_core.exceptions import GoogleAPICallError
 import logging
 
-def custom_field(function):
-    """
-    Decorator to mark a method as a custom field for a BigQueryExporter subclass.
-    """
-    function.is_custom_field = True
-    return function
-
 
 def batch_qs(qs, batch_size=1000):
     """
@@ -34,6 +27,7 @@ def batch_qs(qs, batch_size=1000):
 class BigQueryExporter:
     model = None
     fields = []
+    custom_fields = []
     batch = 1000
     table_name = ''
 
@@ -104,14 +98,12 @@ class BigQueryExporter:
     def _process_queryset(self, queryset, pull_time):
         processed_queryset = []
         for obj in queryset:
-            processed_dict = {'pull_date': pull_time.strftime('%Y-%m-%d %H:%M:%S')}
+            processed_dict = {}
+            processed_dict['pull_date'] = pull_time.strftime('%Y-%m-%d %H:%M:%S')
             for field in self.fields:
+                processed_dict[field] = getattr(obj, field)
+            for field in self.custom_fields:
                 if hasattr(self, field):
-                    if callable(getattr(self, field)) and getattr(getattr(self, field), 'is_custom_field', False):
-                        # If the field is a custom field method
-                        processed_dict[field] = getattr(self, field)(obj)
-                else:
-                    # Regular field
-                    processed_dict[field] = getattr(obj, field)
+                    processed_dict[field] = getattr(self, field)(obj)
             processed_queryset.append(processed_dict)
         return processed_queryset

--- a/bigquery_exporter/base.py
+++ b/bigquery_exporter/base.py
@@ -46,7 +46,7 @@ class BigQueryExporter:
                 raise ValueError(f'Custom field {field} is not defined')
 
     def define_queryset(self):
-        return self.model.objects.all()
+        return self.model.objects.all().order_by('id')
 
     def export(self, pull_date=None, *args, **kwargs):
         pull_time = datetime.datetime.now() if not pull_date else pull_date


### PR DESCRIPTION
[ENGA-932](https://industrydive.atlassian.net/browse/ENGA-932)

### Non-technical Context
For the sake of backfilling or coordinating a pull date across multiple models, we want the export function to accept a pull_date argument

### Technical Context
I added the pull_date parameter which defaults to None. The pull_time used internally by the method is then set to either the specified pull_date, or now if no pull_date is set.

As an aside, I added .order_by('id') to the default queryset method to accommodate the batching of querysets where ordering avoids reprocessing or missing records. 


#### Developer

- [x] Ensure code complies with the [style guide](https://industrydive.atlassian.net/wiki/spaces/TECH/pages/639500407/Tech+Team+s+Style+Guides)
- [x] Devise edge cases to test the bug fix or feature being merged
- [x] Make sure the code is clean and understandable
- [x] Ensure code is not overly inefficient
- [ ] Code changes include a migration
    - [ ] Migration modifies large table and has been run against full db to estimate completion time
    - [ ] Migration modifies a small table and has only been run against slim db
    - [ ] There are no conflicting migration leaf nodes
- [x] Ensure documentation is understandable and accurate, including:
    - [x] Code comments and doc strings
    - [ ] Technical documentation


#### Reviewer

- [x] Ensure code complies with the [style guide](https://industrydive.atlassian.net/wiki/spaces/TECH/pages/639500407/Tech+Team+s+Style+Guides)
    - If there are few or minor issues, add inline comments
    - If there are many issues or it seems like the developer did not follow the style guide, leave a comment asking them to do so
- [x] Devise edge cases to test the bug fix or feature being merged
- [x] Make sure the code is clean and understandable
    - [ ] Ask for inline comments on unclear sections
- [x] Ensure code is not overly inefficient
- [x] Ensure documentation is understandable and accurate, including:
    - [x] Code comments and doc strings
    - [ ] Technical documentation
- [x] There are no conflicting migration leaf nodes



[ENGA-932]: https://industrydive.atlassian.net/browse/ENGA-932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ