### PR TITLE
Resolves ENGA-923 "Modify django-bigquery-exporter base to include decorator for custom_field"

### DIFF
--- a/bigquery_exporter/base.py
+++ b/bigquery_exporter/base.py
@@ -47,9 +47,10 @@ class BigQueryExporter:
         except GoogleAPICallError as e:
             logging.error(f'Error while creating BigQuery client: {e}')
 
-        for field in self.custom_fields:
-            if not hasattr(self, field):
-                raise ValueError(f'Custom field {field} is not defined')
+        for field in self.fields:
+            # check that all fields are valid (either a model field or a custom field method)
+            if not hasattr(self.model, field) and not hasattr(self, field):
+                raise Exception(f'Invalid field {field} for model {self.model}. Must be a model field or a custom field method.')
 
     def define_queryset(self):
         """

--- a/bigquery_exporter/base.py
+++ b/bigquery_exporter/base.py
@@ -9,7 +9,7 @@ def custom_field(method):
     Decorator to mark a method as a custom field for a BigQueryExporter subclass.
     """
     # Ensure that the method has exactly two arguments: self and the Django model instance
-    assert method.__code__.co_argcount != 2, \
+    assert method.__code__.co_argcount == 2, \
         'Custom field methods must have exactly two arguments: self and the Django model instance'
     method.is_custom_field = True
     return method

--- a/bigquery_exporter/base.py
+++ b/bigquery_exporter/base.py
@@ -3,6 +3,7 @@ from google.cloud import bigquery
 from google.api_core.exceptions import GoogleAPICallError
 import logging
 
+
 def custom_field(function):
     """
     Decorator to mark a method as a custom field for a BigQueryExporter subclass.
@@ -50,7 +51,9 @@ class BigQueryExporter:
         for field in self.fields:
             # check that all fields are valid (either a model field or a custom field method)
             if not hasattr(self.model, field) and not hasattr(self, field):
-                raise Exception(f'Invalid field {field} for model {self.model}. Must be a model field or a custom field method.')
+                raise Exception(
+                    f'Invalid field {field} for model {self.model}. Must be a model field or a custom field method.'
+                )
 
     def define_queryset(self):
         """
@@ -73,7 +76,8 @@ class BigQueryExporter:
         Export data to BigQuery.
 
         Args:
-            pull_date (datetime.datetime, optional): The date to pull data from. If not provided, the current date and time will be used.
+            pull_date (datetime.datetime, optional): The datetime used to populate the pull_date field.
+                If not provided, the current date and time will be used.
 
         Raises:
             Exception: If an error occurs while exporting the data.
@@ -107,10 +111,11 @@ class BigQueryExporter:
         for obj in queryset:
             processed_dict = {'pull_date': pull_time.strftime('%Y-%m-%d %H:%M:%S')}
             for field in self.fields:
-                if hasattr(self, field):
-                    if callable(getattr(self, field)) and getattr(getattr(self, field), 'is_custom_field', False):
-                        # If the field is a custom field method
-                        processed_dict[field] = getattr(self, field)(obj)
+                # if the field appears in the exporter class, check if it's a custom field method
+                exporter_field = getattr(self, field, None)
+                if callable(exporter_field) and getattr(exporter_field, 'is_custom_field', False):
+                    # If the field is a custom field method
+                    processed_dict[field] = exporter_field(obj)
                 else:
                     # Regular field
                     processed_dict[field] = getattr(obj, field)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-bigquery-exporter
-version = 0.1.1
+version = 0.1.2
 description = A Django plugin for exporting CMS data to Google BigQuery.
 long_description = file: README.rst
 url = https://www.industrydive.com/

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,3 +29,6 @@ python_requires = >=3.8
 install_requires =
     Django >= 3.2.5
     google-cloud-bigquery >= 2.30.1
+
+[flake8]
+max-line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,5 @@ setup(
     ],
     name='django-bigquery-exporter',
     packages=['bigquery_exporter'],
-    version='0.1.1',
+    version='0.1.2',
 )

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -80,7 +80,7 @@ class TestBigQueryExporter:
 
     def test_custom_field_decorator_sets_custom_attribute_on_callable(self):
         @custom_field
-        def test_field():
+        def test_field(self, obj):
             pass
 
         assert test_field.is_custom_field

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -78,14 +78,14 @@ class TestBigQueryExporter:
         test_exporter.export()
         assert 'Error while exporting' in caplog.text
 
-    def test_custom_field_decorator_sets_is_custom_field_attribute_function(self):
+    def test_custom_field_decorator_sets_custom_attribute_on_callable(self):
         @custom_field
-        def test_field(self):
+        def test_field():
             pass
 
         assert test_field.is_custom_field
 
-    def test_custom_field_decorator(mocker, mock_client, mock_model):
+    def test_custom_field_succeeds_during_processing(mocker, mock_client, mock_model):
         mock_model.field_value = 1
 
         class TestBigQueryExporter(BigQueryExporter):


### PR DESCRIPTION
[ENGA-923](https://industrydive.atlassian.net/browse/ENGA-923)

### Non-technical Context
Replacing the custom_fields array with a single fields array and a decorator to identify custom methods allows for a cleaner implementation and higher visibility for custom fields

### Technical Context
The current decorator implementation is very bare bones. It just adds a custom attribute, "is_custom_field" to the function or method. This allows the `_process_queryset` method to check for the presence of the field, and determine whether to check the model or call the method.

The decorator isn't strictly necessary in this implementation but it does reduce the risk of accidental naming collisions with existing model fields and it opens up the possibility of additional transformations or validation in the future. And it makes it easier to see what methods are custom fields at a glance.

While writing tests for the new decorator, I also refactored the existing tests to DRY up the test class by using a fixture rather than rewriting the test exporter class every time.


#### Developer

- [x] Ensure code complies with the [style guide](https://industrydive.atlassian.net/wiki/spaces/TECH/pages/639500407/Tech+Team+s+Style+Guides)
- [x] Devise edge cases to test the bug fix or feature being merged
- [x] Make sure the code is clean and understandable
- [x] Ensure code is not overly inefficient
- [ ] Code changes include a migration
    - [ ] Migration modifies large table and has been run against full db to estimate completion time
    - [ ] Migration modifies a small table and has only been run against slim db
    - [ ] There are no conflicting migration leaf nodes
- [x] Ensure documentation is understandable and accurate, including:
    - [x] Code comments and doc strings
    - [ ] Technical documentation


#### Reviewer

- [x] Ensure code complies with the [style guide](https://industrydive.atlassian.net/wiki/spaces/TECH/pages/639500407/Tech+Team+s+Style+Guides)
    - If there are few or minor issues, add inline comments
    - If there are many issues or it seems like the developer did not follow the style guide, leave a comment asking them to do so
- [x] Devise edge cases to test the bug fix or feature being merged
- [x] Make sure the code is clean and understandable
    - [ ] Ask for inline comments on unclear sections
- [x] Ensure code is not overly inefficient
- [x] Ensure documentation is understandable and accurate, including:
    - [x] Code comments and doc strings
    - [ ] Technical documentation
- [x] There are no conflicting migration leaf nodes


[ENGA-923]: https://industrydive.atlassian.net/browse/ENGA-923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ