### PR TITLE
ENGA-1457b: Pull Date Options

### DIFF
--- a/bigquery_exporter/base.py
+++ b/bigquery_exporter/base.py
@@ -167,10 +167,11 @@ class BigQueryExporter:
 
         Args:
             pull_date (datetime.datetime, optional): The pull_date to check for. If not provided,
-                the current date and time will be used.
+                method will check for any 
 
         Returns:
-            bool: True if the table has data for the given pull_date, False otherwise.
+            bool: True if the table has data for a given pull date if one is provided, or any data at all if no pull_date.
+                    False otherwise.
         """
         if pull_date and self.include_pull_date:
             # Convert pull_date to UTC if it has timezone info

--- a/bigquery_exporter/base.py
+++ b/bigquery_exporter/base.py
@@ -242,7 +242,7 @@ class BigQueryExporter:
         """
         if isinstance(value, datetime.datetime):
             # Convert datetime to UTC if it has timezone info
-            handle_datetime_value(value)
+            return handle_datetime_value(value)
         elif isinstance(value, UUID):
             return str(value)
         elif value is None:

--- a/bigquery_exporter/base.py
+++ b/bigquery_exporter/base.py
@@ -9,6 +9,7 @@ from google.api_core.exceptions import RetryError
 from google.api_core.retry import Retry
 
 from bigquery_exporter.errors import BigQueryExporterInitError, BigQueryExporterValidationError
+from bigquery_exporter.helpers import handle_datetime_value
 
 from django.db.models import QuerySet
 
@@ -241,12 +242,7 @@ class BigQueryExporter:
         """
         if isinstance(value, datetime.datetime):
             # Convert datetime to UTC if it has timezone info
-            if value.tzinfo is not None:
-                utc_value = value.astimezone(pytz.UTC)
-            else:
-                # If naive datetime (no timezone), assume it's in UTC
-                utc_value = pytz.UTC.localize(value)
-            return utc_value.strftime('%Y-%m-%d %H:%M:%S')
+            handle_datetime_value(value)
         elif isinstance(value, UUID):
             return str(value)
         elif value is None:

--- a/bigquery_exporter/helpers.py
+++ b/bigquery_exporter/helpers.py
@@ -1,0 +1,10 @@
+import pytz
+
+def handle_datetime_value(value):
+    if value.tzinfo is not None:
+        utc_value = value.astimezone(pytz.UTC)
+    else:
+        # If naive datetime (no timezone), assume it's in UTC
+        utc_value = pytz.UTC.localize(value)
+    return utc_value.strftime('%Y-%m-%d %H:%M:%S')
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytest >= 7.3.0
 pytest-xdist >= 2.3.0
 pytest-mock >= 3.6.1
 pytest-cov >= 2.12.1
+pytz >= 2023.3

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ setup(
         'Django >= 3.2.4',
         'google-auth >= 1.32.1',
         'google-cloud-bigquery >= 2.30.1',
+        'pytz >= 2023.3',
     ],
     name='django-bigquery-exporter',
     packages=['bigquery_exporter'],


### PR DESCRIPTION
[ENGA-1457](https:/industrydive.atlassian.net/browse/ENGA-1457)

### Non-technical Context
This change adds timezone support to the BigQuery Exporter and makes the pull date field configurable, allowing for better control over exported data and more reliable timezone handling.

### Technical Context
1. **bigquery_exporter/base.py:** Added proper timezone handling to ensure all datetime objects are converted to UTC before export. Added two new class attributes (`include_pull_date` and `pull_date_field_name`) to control whether pull dates are included in exported data and customize the field name. Modified `_process_queryset()`, `_sanitize_value()`, and `table_has_data()` methods to support these features.

2. **requirements.txt and setup.py:** Added `pytz` as a dependency with version requirement `>= 2023.3` to support timezone operations.

3. **tests/test_base.py:** Added tests for:
   - Processing querysets with and without pull date inclusion
   - Custom pull date field naming
   - Naive and timezone-aware datetime handling
   - UTC conversion in the table_has_data method

### Manual Testing Instructions
1. Create a BigQueryExporter subclass with `include_pull_date = True` and verify pull dates are included in exports
2. Test with timezone-aware datetimes to confirm proper UTC conversion
3. Set a custom `pull_date_field_name` and verify the field appears with the specified name in the export

#### Developer

- [x] Ensure code complies with the [style guide](mdc:https:/industrydive.atlassian.net/wiki/spaces/TECH/pages/639500407/Tech+Team+s+Style+Guides)
- [x] Devise edge cases to test the bug fix or feature being merged
- [x] Make sure the code is clean and understandable
- [x] Ensure code is not overly inefficient
- [ ] Ensure user permissions have been included (for new features) or updated (for revisions), if necessary
- [ ] Ensure documentation is understandable and accurate, including:
    - [ ] Code comments and doc strings
    - [ ] Technical documentation


#### Reviewer
- [x] Ensure code complies with the [style guide](mdc:https:/industrydive.atlassian.net/wiki/spaces/TECH/pages/639500407/Tech+Team+s+Style+Guides)
    - If there are few or minor issues, add inline comments
    - If there are many issues or it seems like the developer did not follow the style guide, leave a comment asking them to do so
- [x] Devise edge cases to test the bug fix or feature being merged
- [x] Make sure the code is clean and understandable
    - [ ] Ask for inline comments on unclear sections
- [x] Ensure code is not overly inefficient
- [x] Ensure user permissions have been included (for new features) or updated (for revisions), if necessary
- [x] Ensure documentation is understandable and accurate, including:
    - [x] Code comments and doc strings
    - [ ] Technical documentation
- [ ] There are no conflicting migration leaf nodes

[ENGA-1457]: https://industrydive.atlassian.net/browse/ENGA-1457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ