### PR TITLE
ENGA-1457c "handle different field types in replace null with empty"

### DIFF
--- a/bigquery_exporter/clients/__init__.py
+++ b/bigquery_exporter/clients/__init__.py
@@ -1,0 +1,3 @@
+"""
+Client interfaces and implementations for BigQuery
+"""

--- a/bigquery_exporter/clients/google_client.py
+++ b/bigquery_exporter/clients/google_client.py
@@ -33,10 +33,10 @@ class GoogleBigQueryClient(BigQueryClientInterface):
             BigQueryExporterInitError: If an error occurs while initializing the client.
         """
         try:
-            if credentials:
+            if credentials:  # use service account credentials if provided
                 service_account_info = service_account.Credentials.from_service_account_file(credentials)
                 self.client = bigquery.Client(project=project, credentials=service_account_info)
-            else:
+            else:  # otherwise client will search application default credentials
                 self.client = bigquery.Client(project=project)
         except GoogleAPICallError as e:
             logger.error(f"Error creating BigQuery client: {e}")

--- a/bigquery_exporter/clients/google_client.py
+++ b/bigquery_exporter/clients/google_client.py
@@ -1,0 +1,82 @@
+"""
+Google Cloud BigQuery client implementation
+"""
+import logging
+from typing import Any, Dict, List, Optional
+
+from google.cloud import bigquery
+from google.oauth2 import service_account
+from google.api_core.exceptions import GoogleAPICallError
+from google.api_core.retry import Retry
+
+from bigquery_exporter.clients.interface import BigQueryClientInterface
+from bigquery_exporter.errors import BigQueryExporterInitError
+
+
+logger = logging.getLogger(__name__)
+
+
+class GoogleBigQueryClient(BigQueryClientInterface):
+    """
+    Implementation of BigQueryClientInterface that uses the Google Cloud BigQuery client.
+    """
+
+    def __init__(self, project: Optional[str] = None, credentials: Optional[str] = None):
+        """
+        Initialize a GoogleBigQueryClient.
+
+        Args:
+            project: The Google Cloud project ID.
+            credentials: The path to the service account credentials file.
+
+        Raises:
+            BigQueryExporterInitError: If an error occurs while initializing the client.
+        """
+        try:
+            if credentials:
+                service_account_info = service_account.Credentials.from_service_account_file(credentials)
+                self.client = bigquery.Client(project=project, credentials=service_account_info)
+            else:
+                self.client = bigquery.Client(project=project)
+        except GoogleAPICallError as e:
+            logger.error(f"Error creating BigQuery client: {e}")
+            raise BigQueryExporterInitError(e)
+
+    def get_table(self, table_id: str) -> Any:
+        """
+        Gets a table from BigQuery.
+
+        Args:
+            table_id: The ID of the table to get.
+
+        Returns:
+            The BigQuery table.
+        """
+        return self.client.get_table(table_id)
+
+    def insert_rows(self, table: Any, rows: List[Dict[str, Any]],
+                   retry: Optional[Retry] = None) -> List[Dict[str, Any]]:
+        """
+        Inserts rows into a BigQuery table.
+
+        Args:
+            table: The table to insert rows into.
+            rows: The rows to insert.
+            retry: A retry object used for retrying requests.
+
+        Returns:
+            A list of errors that occurred while inserting rows, empty if no errors.
+        """
+        return self.client.insert_rows(table, rows, retry=retry)
+
+    def query(self, query: str) -> Any:
+        """
+        Executes a query in BigQuery.
+
+        Args:
+            query: The query to execute.
+
+        Returns:
+            A query job.
+        """
+        return self.client.query(query)

--- a/bigquery_exporter/clients/interface.py
+++ b/bigquery_exporter/clients/interface.py
@@ -1,0 +1,55 @@
+"""
+Interfaces for BigQuery clients
+"""
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional, Union
+from google.api_core.retry import Retry
+
+
+class BigQueryClientInterface(ABC):
+    """
+    Interface for BigQuery clients.
+    This defines the contract that all BigQuery client implementations must follow.
+    """
+
+    @abstractmethod
+    def get_table(self, table_id: str) -> Any:
+        """
+        Gets a table from BigQuery.
+
+        Args:
+            table_id: The ID of the table to get.
+
+        Returns:
+            The BigQuery table.
+        """
+        pass
+
+    @abstractmethod
+    def insert_rows(self, table: Any, rows: List[Dict[str, Any]],
+                   retry: Optional[Retry] = None) -> List[Dict[str, Any]]:
+        """
+        Inserts rows into a BigQuery table.
+
+        Args:
+            table: The table to insert rows into.
+            rows: The rows to insert.
+            retry: A retry object used for retrying requests.
+
+        Returns:
+            A list of errors that occurred while inserting rows, empty if no errors.
+        """
+        pass
+
+    @abstractmethod
+    def query(self, query: str) -> Any:
+        """
+        Executes a query in BigQuery.
+
+        Args:
+            query: The query to execute.
+
+        Returns:
+            A query job.
+        """
+        pass

--- a/bigquery_exporter/constants.py
+++ b/bigquery_exporter/constants.py
@@ -1,0 +1,19 @@
+"""
+Constants for the BigQuery Exporter package.
+"""
+
+# Default values to use for each BigQuery field type when replacing None values
+BQ_TYPE_DEFAULTS = {
+    'STRING': '',
+    'INTEGER': 0,
+    'FLOAT': 0.0,
+    'NUMERIC': 0.0,
+    'BOOLEAN': False,
+    'TIMESTAMP': '',
+    'DATE': '',
+    'TIME': '',
+    'DATETIME': '',
+    'RECORD': {},
+    'BYTES': b'',
+    'JSON': '{}'
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,7 +75,7 @@ def mock_model(mocker):
 
 @pytest.fixture
 def test_exporter_factory(mocker, mock_model, qs_factory, bigquery_client_factory):
-    def create_test_exporter(qs_size=5, table='test_table', batch_size=1000, qs_ordered=True, client=None, replace_nulls=False):
+    def create_test_exporter(qs_size=5, table='test_table', batch_size=1000, qs_ordered=True, client=None, replace_nulls=False, mock_process_queryset=True):
         class TestExporter(BigQueryExporter):
             model = mock_model
             table_name = table
@@ -88,7 +88,11 @@ def test_exporter_factory(mocker, mock_model, qs_factory, bigquery_client_factor
         exporter = TestExporter(client=client)
         exporter.define_queryset = mocker.MagicMock()
         exporter.define_queryset.return_value = qs_factory(qs_size, qs_ordered)
-        exporter._process_queryset = mocker.MagicMock()
+
+        # Only mock _process_queryset if explicitly requested
+        if mock_process_queryset:
+            exporter._process_queryset = mocker.MagicMock()
+
         exporter._push_to_bigquery = mocker.MagicMock()
         return exporter
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,17 @@ import pytest
 from django.db import models
 from google.cloud import bigquery
 
+from bigquery_exporter.base import BigQueryExporter
+from bigquery_exporter.clients.interface import BigQueryClientInterface
+
+@pytest.fixture
+def mock_field_factory(mocker):
+    def create_mock_field(name, field_type):
+        field = mocker.MagicMock()
+        field.name = name
+        field.field_type = field_type
+        return field
+    return create_mock_field
 
 @pytest.fixture
 def qs_factory(mocker):
@@ -21,29 +32,35 @@ def qs_factory(mocker):
 
 
 @pytest.fixture
-def bigquery_client_factory(mocker):
+def bigquery_client_factory(mocker, mock_field_factory):
     def _factory(table_name, fields):
-        schema = [bigquery.SchemaField(field, 'STRING') for field in fields]
+        # Convert any string fields to mock field objects
+        processed_fields = []
+        for field in fields:
+            if isinstance(field, str):
+                processed_fields.append(mock_field_factory(field, 'STRING'))
+            else:
+                processed_fields.append(field)
 
-        # Mocking the BigQuery client
-        client = mocker.Mock(spec=bigquery.Client)
-        # Mocking the table and schema
-        table = mocker.MagicMock(table_name=table_name, schema=schema)
-        # Setting up the client to return the mocked table
+        # If no fields provided, create default fields
+        if not processed_fields:
+            processed_fields = [mock_field_factory(f'field_{x}', 'STRING') for x in range(3)]
+
+        # Create a mock table
+        table = mocker.MagicMock(table_name=table_name, schema=processed_fields)
+
+        # Create a mock client that implements BigQueryClientInterface
+        client = mocker.MagicMock(spec=BigQueryClientInterface)
         client.get_table.return_value = table
+
+        # Configure the query method to return a job with a result method
+        query_job = mocker.MagicMock()
+        query_job.result.return_value = [(0,)]  # Default return value for count queries
+        client.query.return_value = query_job
 
         return client
 
     return _factory
-
-
-@pytest.fixture
-def mock_client(mocker):
-    client = mocker.patch('bigquery_exporter.base.bigquery.Client')
-    table = mocker.MagicMock()
-    table.schema = [mocker.MagicMock(name='field1'), mocker.MagicMock(name='field2')]
-    client.get_table.return_value = table
-    return client
 
 
 @pytest.fixture
@@ -54,3 +71,25 @@ def mock_model(mocker):
     model.objects = mocker.MagicMock(spec=models.Manager)
     model.objects.all.return_value = queryset
     return model
+
+
+@pytest.fixture
+def test_exporter_factory(mocker, mock_model, qs_factory, bigquery_client_factory):
+    def create_test_exporter(qs_size=5, table='test_table', batch_size=1000, qs_ordered=True, client=None, replace_nulls=False):
+        class TestExporter(BigQueryExporter):
+            model = mock_model
+            table_name = table
+            batch = batch_size
+            replace_nulls_with_empty = replace_nulls
+
+        if client is None:
+            client = bigquery_client_factory(table, [])
+
+        exporter = TestExporter(client=client)
+        exporter.define_queryset = mocker.MagicMock()
+        exporter.define_queryset.return_value = qs_factory(qs_size, qs_ordered)
+        exporter._process_queryset = mocker.MagicMock()
+        exporter._push_to_bigquery = mocker.MagicMock()
+        return exporter
+
+    return create_test_exporter

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -95,13 +95,16 @@ class TestBigQueryExporter:
         mock_client = bigquery_client_factory('test_table', ['field_value', 'custom_field'])
         exporter = test_exporter_factory(client=mock_client, mock_process_queryset=False)
 
-        # Add the custom field method to the exporter
-        @custom_field
-        def custom_field_method(self, obj):
-            return obj.field_value * 2
+        class TestBigQueryExporter(BigQueryExporter):
+            model = mock_model
+            table_name = 'test_table'
+            fields = ['field_value', 'custom_field']
 
-        exporter.custom_field = custom_field_method.__get__(exporter, type(exporter))
-        exporter.fields = ['field_value', 'custom_field']
+            @custom_field
+            def custom_field(self, obj):
+                return obj.field_value * 2
+
+        exporter = TestBigQueryExporter(client=mock_client)
 
         mock_queryset = [mock_model]
         pull_time = datetime.datetime(2023, 1, 1, 0, 0, 0)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -89,23 +89,20 @@ class TestBigQueryExporter:
 
         assert test_field.is_custom_field
 
-    def test_custom_field_succeeds_during_processing(self, bigquery_client_factory, mocker, mock_model):
+    def test_custom_field_succeeds_during_processing(self, bigquery_client_factory, mocker, mock_model, test_exporter_factory):
         mock_model.field_value = 1
         # mock the client to return a table with the field 'field_value' and 'custom_field'
         mock_client = bigquery_client_factory('test_table', ['field_value', 'custom_field'])
-        mocker.patch('bigquery_exporter.base.bigquery.Client', return_value=mock_client)
+        exporter = test_exporter_factory(client=mock_client, mock_process_queryset=False)
 
-        class TestBigQueryExporter(BigQueryExporter):
-            model = mock_model
-            table_name = 'test_table'
-            fields = ['field_value', 'custom_field']
+        # Add the custom field method to the exporter
+        @custom_field
+        def custom_field_method(self, obj):
+            return obj.field_value * 2
 
-            @custom_field
-            def custom_field(self, obj):
-                return obj.field_value * 2
+        exporter.custom_field = custom_field_method.__get__(exporter, type(exporter))
+        exporter.fields = ['field_value', 'custom_field']
 
-        # make sure we're mocking bigquery.Client
-        exporter = TestBigQueryExporter()
         mock_queryset = [mock_model]
         pull_time = datetime.datetime(2023, 1, 1, 0, 0, 0)
         processed_data = exporter._process_queryset(mock_queryset, pull_time)
@@ -116,19 +113,14 @@ class TestBigQueryExporter:
             assert processed['custom_field'] == 2
             assert 'pull_date' not in processed  # pull_date should not be included by default
 
-    def test_process_queryset_with_pull_date(self, bigquery_client_factory, mocker, mock_model):
+    def test_process_queryset_with_pull_date(self, bigquery_client_factory, mocker, mock_model, test_exporter_factory):
         mock_model.field_value = 1
         # mock the client to return a table with the field 'field_value' and 'pull_date'
         mock_client = bigquery_client_factory('test_table', ['field_value', 'pull_date'])
-        mocker.patch('bigquery_exporter.base.bigquery.Client', return_value=mock_client)
+        exporter = test_exporter_factory(client=mock_client, mock_process_queryset=False)
+        exporter.fields = ['field_value']
+        exporter.include_pull_date = True
 
-        class TestBigQueryExporter(BigQueryExporter):
-            model = mock_model
-            table_name = 'test_table'
-            fields = ['field_value']
-            include_pull_date = True
-
-        exporter = TestBigQueryExporter()
         mock_queryset = [mock_model]
         pull_time = datetime.datetime(2023, 1, 1, 0, 0, 0)
         processed_data = exporter._process_queryset(mock_queryset, pull_time)
@@ -138,20 +130,14 @@ class TestBigQueryExporter:
             assert processed['field_value'] == 1
             assert processed['pull_date'] == pull_time.strftime('%Y-%m-%d %H:%M:%S')
 
-    def test_process_queryset_with_custom_pull_date_name(self, bigquery_client_factory, mocker, mock_model):
+    def test_process_queryset_with_custom_pull_date_name(self, bigquery_client_factory, mocker, mock_model, test_exporter_factory):
         mock_model.field_value = 1
-        # mock the client to return a table with the field 'field_value' and 'export_time'
         mock_client = bigquery_client_factory('test_table', ['field_value', 'export_time'])
-        mocker.patch('bigquery_exporter.base.bigquery.Client', return_value=mock_client)
+        exporter = test_exporter_factory(client=mock_client, mock_process_queryset=False)
+        exporter.fields = ['field_value']
+        exporter.include_pull_date = True
+        exporter.pull_date_field_name = 'export_time'
 
-        class TestBigQueryExporter(BigQueryExporter):
-            model = mock_model
-            table_name = 'test_table'
-            fields = ['field_value']
-            include_pull_date = True
-            pull_date_field_name = 'export_time'
-
-        exporter = TestBigQueryExporter()
         mock_queryset = [mock_model]
         pull_time = datetime.datetime(2023, 1, 1, 0, 0, 0)
         processed_data = exporter._process_queryset(mock_queryset, pull_time)
@@ -210,18 +196,11 @@ class TestBigQueryExporter:
             test_exporter.export()
         assert 'Queryset must be ordered (using .order_by()) when batch size (3) is smaller than queryset size (5)' in str(exc_info.value)
 
-    def test_sanitize_value_converts_naive_datetime_to_utc(self, bigquery_client_factory, mocker, mock_model):
+    def test_sanitize_value_converts_naive_datetime_to_utc(self, bigquery_client_factory, mocker, mock_model, test_exporter_factory):
         """Test that naive datetime objects are converted to UTC before stringifying"""
         # mock the client to return a table with the required fields
         mock_client = bigquery_client_factory('test_table', ['field_value'])
-        mocker.patch('bigquery_exporter.base.bigquery.Client', return_value=mock_client)
-
-        class TestBigQueryExporter(BigQueryExporter):
-            model = mock_model
-            table_name = 'test_table'
-            fields = []
-
-        exporter = TestBigQueryExporter()
+        exporter = test_exporter_factory(client=mock_client)
 
         # Create a naive datetime
         naive_dt = datetime.datetime(2023, 1, 1, 12, 0, 0)
@@ -234,18 +213,11 @@ class TestBigQueryExporter:
         expected = pytz.UTC.localize(naive_dt).strftime('%Y-%m-%d %H:%M:%S')
         assert result == expected
 
-    def test_sanitize_value_preserves_aware_datetime_timezone(self, bigquery_client_factory, mocker, mock_model):
+    def test_sanitize_value_preserves_aware_datetime_timezone(self, bigquery_client_factory, mocker, mock_model, test_exporter_factory):
         """Test that timezone-aware datetime objects are correctly converted to UTC"""
         # mock the client to return a table with the required fields
         mock_client = bigquery_client_factory('test_table', ['field_value'])
-        mocker.patch('bigquery_exporter.base.bigquery.Client', return_value=mock_client)
-
-        class TestBigQueryExporter(BigQueryExporter):
-            model = mock_model
-            table_name = 'test_table'
-            fields = []
-
-        exporter = TestBigQueryExporter()
+        exporter = test_exporter_factory(client=mock_client)
 
         # Create a timezone-aware datetime (UTC+2)
         # Using pytz to create a timezone-aware datetime
@@ -258,20 +230,15 @@ class TestBigQueryExporter:
         expected = utc_time.strftime('%Y-%m-%d %H:%M:%S')
         assert result == expected
 
-    def test_process_queryset_applies_utc_conversion_to_pull_date(self, bigquery_client_factory, mocker, mock_model):
+    def test_process_queryset_applies_utc_conversion_to_pull_date(self, bigquery_client_factory, mocker, mock_model, test_exporter_factory):
         """Test that pull_date is properly converted to UTC in _process_queryset"""
         mock_model.field_value = 1
         # mock the client to return a table with the required fields
         mock_client = bigquery_client_factory('test_table', ['field_value', 'pull_date'])
-        mocker.patch('bigquery_exporter.base.bigquery.Client', return_value=mock_client)
+        exporter = test_exporter_factory(client=mock_client, mock_process_queryset=False)
+        exporter.include_pull_date = True
+        exporter.fields = ['field_value']
 
-        class TestBigQueryExporter(BigQueryExporter):
-            model = mock_model
-            table_name = 'test_table'
-            fields = []
-            include_pull_date = True
-
-        exporter = TestBigQueryExporter()
         mock_queryset = [mock_model]
 
         # Create a timezone-aware datetime (UTC+2)
@@ -298,7 +265,7 @@ class TestBigQueryExporter:
         expected_query = f'SELECT COUNT(*) FROM {test_exporter.table_name} WHERE DATE(pull_date) = "2023-01-01"'
         test_exporter.client.query.assert_called_with(expected_query)
 
-    def test_sanitize_value_with_type_specific_defaults(self, bigquery_client_factory, mocker, mock_field_factory):
+    def test_sanitize_value_with_type_specific_defaults(self, bigquery_client_factory, mocker, mock_field_factory, test_exporter_factory):
         """Test _sanitize_value with replace_nulls_with_empty=True and different field types"""
         # Create mock schema fields with proper attributes
         string_field = mock_field_factory('string_field', 'STRING')
@@ -308,18 +275,6 @@ class TestBigQueryExporter:
         json_field = mock_field_factory('json_field', 'JSON')
         unknown_field = mock_field_factory('unknown_field', 'UNKNOWN_TYPE')
 
-        # Create a mock table with fields of different types
-        mock_table = mocker.MagicMock()
-        mock_table.schema = [
-            string_field,
-            integer_field,
-            float_field,
-            boolean_field,
-            json_field,
-            unknown_field
-        ]
-
-        # Create a mock exporter with replace_nulls_with_empty=True
         mock_client = bigquery_client_factory('test_table', [
             string_field,
             integer_field,
@@ -329,17 +284,7 @@ class TestBigQueryExporter:
             unknown_field
         ])
 
-        class TestExporter(BigQueryExporter):
-            model = mocker.MagicMock()
-            table_name = 'test_table'
-            fields = []
-            replace_nulls_with_empty = True
-
-        # Mock the client creation to avoid actual API calls
-        mocker.patch('bigquery_exporter.base.bigquery.Client', return_value=mock_client)
-
-        exporter = TestExporter()
-        exporter.table = mock_table  # Set the table directly
+        exporter = test_exporter_factory(client=mock_client, replace_nulls=True)
 
         # Test with None values for different field types
         assert exporter._sanitize_value(None, 'string_field') == ''
@@ -352,88 +297,40 @@ class TestBigQueryExporter:
         # Field not in schema should default to empty string
         assert exporter._sanitize_value(None, 'nonexistent_field') == ''
 
-    def test_sanitize_value_with_none_values_disabled_replacement(self, mocker):
+    def test_sanitize_value_with_none_values_disabled_replacement(self, mocker, bigquery_client_factory, mock_field_factory, test_exporter_factory):
         """Test _sanitize_value with replace_nulls_with_empty=False"""
-        # Create mock schema fields with proper attributes
-        string_field = mocker.MagicMock()
-        string_field.name = 'string_field'
-        string_field.field_type = 'STRING'
+        string_field = mock_field_factory('string_field', 'STRING')
+        integer_field = mock_field_factory('integer_field', 'INTEGER')
 
-        integer_field = mocker.MagicMock()
-        integer_field.name = 'integer_field'
-        integer_field.field_type = 'INTEGER'
-
-        # Create a mock table
-        mock_table = mocker.MagicMock()
-        mock_table.schema = [
+        mock_client = bigquery_client_factory('test_table', [
             string_field,
             integer_field
-        ]
+        ])
 
-        # Create a mock exporter with replace_nulls_with_empty=False
-        mock_client = mocker.MagicMock()
-        mock_client.get_table.return_value = mock_table
-
-        class TestExporter(BigQueryExporter):
-            model = mocker.MagicMock()
-            table_name = 'test_table'
-            fields = []
-            replace_nulls_with_empty = False
-
-        # Mock the client creation to avoid actual API calls
-        mocker.patch('bigquery_exporter.base.bigquery.Client', return_value=mock_client)
-
-        exporter = TestExporter()
-        exporter.table = mock_table  # Set the table directly
+        exporter = test_exporter_factory(client=mock_client, replace_nulls=False)
 
         # Test with None values - should remain None
         assert exporter._sanitize_value(None, 'string_field') is None
         assert exporter._sanitize_value(None, 'integer_field') is None
         assert exporter._sanitize_value(None, 'nonexistent_field') is None
 
-    def test_sanitize_value_with_non_none_values(self, mocker):
+    def test_sanitize_value_with_non_none_values(self, mocker, bigquery_client_factory, mock_field_factory, test_exporter_factory):
         """Test _sanitize_value with non-None values (should not be affected by type-specific defaults)"""
         # Create mock schema fields with proper attributes
-        string_field = mocker.MagicMock()
-        string_field.name = 'string_field'
-        string_field.field_type = 'STRING'
+        string_field = mock_field_factory('string_field', 'STRING')
+        integer_field = mock_field_factory('integer_field', 'INTEGER')
+        float_field = mock_field_factory('float_field', 'FLOAT')
+        boolean_field = mock_field_factory('boolean_field', 'BOOLEAN')
 
-        integer_field = mocker.MagicMock()
-        integer_field.name = 'integer_field'
-        integer_field.field_type = 'INTEGER'
-
-        float_field = mocker.MagicMock()
-        float_field.name = 'float_field'
-        float_field.field_type = 'FLOAT'
-
-        boolean_field = mocker.MagicMock()
-        boolean_field.name = 'boolean_field'
-        boolean_field.field_type = 'BOOLEAN'
-
-        # Create a mock table
-        mock_table = mocker.MagicMock()
-        mock_table.schema = [
+        # Create a mock client with table
+        mock_client = bigquery_client_factory('test_table', [
             string_field,
             integer_field,
             float_field,
             boolean_field
-        ]
+        ])
 
-        # Create a mock exporter with replace_nulls_with_empty=True
-        mock_client = mocker.MagicMock()
-        mock_client.get_table.return_value = mock_table
-
-        class TestExporter(BigQueryExporter):
-            model = mocker.MagicMock()
-            table_name = 'test_table'
-            fields = []
-            replace_nulls_with_empty = True
-
-        # Mock the client creation to avoid actual API calls
-        mocker.patch('bigquery_exporter.base.bigquery.Client', return_value=mock_client)
-
-        exporter = TestExporter()
-        exporter.table = mock_table  # Set the table directly
+        exporter = test_exporter_factory(client=mock_client, replace_nulls=True)
 
         # Test with non-None values - should remain unchanged
         assert exporter._sanitize_value("test", 'string_field') == "test"


### PR DESCRIPTION
[ENGA-1457](https://industrydive.atlassian.net/browse/ENGA-1457)

### Non-technical Context
This change improves how null values are handled when exporting data to BigQuery, preventing errors that occur when empty strings are assigned to numeric fields.

### Technical Context
1. **bigquery_exporter/constants.py:** Created a new constants file that contains a dictionary mapping BigQuery field types to appropriate falsy default values (e.g., 0 for INTEGER, 0.0 for FLOAT, False for BOOLEAN, etc.).

2. **bigquery_exporter/base.py:** Enhanced the `_sanitize_value` method to handle None values based on field types. When `replace_nulls_with_empty` is enabled and a None value is encountered, the method now:
   - Checks the BigQuery schema to determine the field's type
   - Returns the appropriate type-specific default (0 for integers, 0.0 for floats, etc.) based on the field type
   - Falls back to empty string if the field isn't found or has an unknown type

3. **tests/test_base.py:** Added tests to verify the new type-specific default functionality:
   - Testing different field types get appropriate defaults (strings, integers, floats, booleans, etc.)
   - Verifying that non-None values remain unchanged
   - Ensuring fields not in the schema get handled gracefully
   - Confirming that disabling `replace_nulls_with_empty` still preserves None values

### Manual Testing Instructions
To test this functionality:
1. Create a BigQueryExporter with `replace_nulls_with_empty=True`
2. Export a model with null values in various field types
3. Verify that each null value is replaced with the appropriate default (e.g., 0 for INTEGER fields, empty string for STRING fields)

#### Developer

- [x] Ensure code complies with the [style guide](https://industrydive.atlassian.net/wiki/spaces/TECH/pages/639500407/Tech+Team+s+Style+Guides)
- [x] Devise edge cases to test the bug fix or feature being merged
- [x] Make sure the code is clean and understandable
- [x] Ensure code is not overly inefficient
- [ ] Ensure user permissions have been included (for new features) or updated (for revisions), if necessary

#### Reviewer
- [ ] Ensure code complies with the [style guide](https://industrydive.atlassian.net/wiki/spaces/TECH/pages/639500407/Tech+Team+s+Style+Guides)
    - If there are few or minor issues, add inline comments
    - If there are many issues or it seems like the developer did not follow the style guide, leave a comment asking them to do so
- [ ] Devise edge cases to test the bug fix or feature being merged
- [ ] Make sure the code is clean and understandable
    - [ ] Ask for inline comments on unclear sections
- [ ] Ensure code is not overly inefficient
- [ ] Ensure user permissions have been included (for new features) or updated (for revisions), if necessary
- [ ] Ensure documentation is understandable and accurate, including:
    - [ ] Code comments and doc strings
    - [ ] Technical documentation
- [ ] There are no conflicting migration leaf nodes

[ENGA-1457]: https://industrydive.atlassian.net/browse/ENGA-1457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ