### PR TITLE
ENGA-1712 add support for initialization with existing credentials object

### DIFF
--- a/bigquery_exporter/base.py
+++ b/bigquery_exporter/base.py
@@ -78,8 +78,11 @@ class BigQueryExporter:
         Args:
             project (str, optional): The Google Cloud project id. If not provided, the default project
                 will be used.
-            credentials (str, optional): The path to the service account credentials file. If not provided,
-                the default credentials will be used.
+            credentials (optional): Credentials to use for authentication. Can be either:
+                                    - str: Path to a service account JSON key file
+                                    - google.oauth2.service_account.Credentials: An existing
+                                      service account credentials object
+                                    If None, falls back to Application Default Credentials (ADC).
             client (BigQueryClientInterface, optional): A pre-configured BigQuery client instance.
                 If provided, project and credentials are ignored.
 

--- a/bigquery_exporter/clients/google_client.py
+++ b/bigquery_exporter/clients/google_client.py
@@ -2,7 +2,7 @@
 Google Cloud BigQuery client implementation
 """
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from google.cloud import bigquery
 from google.oauth2 import service_account
@@ -21,23 +21,39 @@ class GoogleBigQueryClient(BigQueryClientInterface):
     Implementation of BigQueryClientInterface that uses the Google Cloud BigQuery client.
     """
 
-    def __init__(self, project: Optional[str] = None, credentials: Optional[str] = None):
+    def __init__(
+            self,
+            project: Optional[str] = None,
+            credentials: Optional[Union[str, service_account.Credentials]] = None,
+        ):
         """
         Initialize a GoogleBigQueryClient.
 
         Args:
             project: The Google Cloud project ID.
-            credentials: The path to the service account credentials file.
+            credentials: Credentials to use for authentication. Can be either:
+                         - str: Path to a service account JSON key file
+                         - google.oauth2.service_account.Credentials: An existing
+                           service account credentials object
+                         If None, falls back to Application Default Credentials (ADC).
 
         Raises:
             BigQueryExporterInitError: If an error occurs while initializing the client.
+            ValueError: If credentials is provided but has an unsupported type.
         """
         try:
-            if credentials:  # use service account credentials if provided
-                service_account_info = service_account.Credentials.from_service_account_file(credentials)
-                self.client = bigquery.Client(project=project, credentials=service_account_info)
-            else:  # otherwise client will search application default credentials
+            # Application Default Credentials (ADC)
+            if credentials is None:
                 self.client = bigquery.Client(project=project)
+            # Path to service account JSON key file
+            elif isinstance(credentials, str):
+                credentials_obj = service_account.Credentials.from_service_account_file(credentials)
+                self.client = bigquery.Client(project=project, credentials=credentials_obj)
+            # Existing service account credentials object            
+            elif isinstance(credentials, service_account.Credentials):
+                self.client = bigquery.Client(project=project, credentials=credentials)
+            else:
+                raise ValueError(f'Unsupported credentials type: "{type(credentials).__name__}". Expected str or service_account.Credentials.')
         except GoogleAPICallError as e:
             logger.error(f"Error creating BigQuery client: {e}")
             raise BigQueryExporterInitError(e)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-bigquery-exporter
-version = 0.2.3
+version = 0.2.4
 description = A Django plugin for exporting CMS data to Google BigQuery.
 long_description = file: README.rst
 url = https://www.industrydive.com/

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ setup(
     ],
     name='django-bigquery-exporter',
     packages=find_packages(),
-    version='0.2.3',
+    version='0.2.4',
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,8 @@
 import pytest
+from unittest.mock import MagicMock
 
 from django.db import models
-from google.cloud import bigquery
+from google.oauth2 import service_account
 
 from bigquery_exporter.base import BigQueryExporter
 from bigquery_exporter.clients.interface import BigQueryClientInterface
@@ -97,3 +98,19 @@ def test_exporter_factory(mocker, mock_model, qs_factory, bigquery_client_factor
         return exporter
 
     return create_test_exporter
+
+
+@pytest.fixture
+def mock_service_account_credentials():
+    """ Fixture for a fake service account credentials object """
+    return MagicMock(spec=service_account.Credentials)
+
+
+@pytest.fixture
+def fake_table():
+    """ Fake BigQuery Table object """
+    table = MagicMock()
+    table.project = 'fake-project'
+    table.dataset_id = 'fake_dataset'
+    table.table_id = 'fake_table'
+    return table

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,98 @@
+import pytest
+from unittest.mock import MagicMock
+
+from google.api_core.exceptions import GoogleAPICallError
+
+from bigquery_exporter.clients.google_client import GoogleBigQueryClient
+from bigquery_exporter.errors import BigQueryExporterInitError
+
+
+class TestGoogleBigQueryClient:
+    """
+    Unit tests for GoogleBigQueryClient
+    """
+    def test_init_with_no_credentials_uses_adc(self, mocker):
+        mock_bq_client_class = mocker.patch('bigquery_exporter.clients.google_client.bigquery.Client')
+        client = GoogleBigQueryClient(project='my-project')
+
+        mock_bq_client_class.assert_called_once_with(project='my-project')
+        assert client.client == mock_bq_client_class.return_value
+
+    def test_init_with_str_credentials(self, mocker):
+        project = 'fake-project'
+        fake_path = '/path/to/fake-service-account.json'
+
+        mock_bq_client_class = mocker.patch('bigquery_exporter.clients.google_client.bigquery.Client')
+        mock_from_file = mocker.patch('google.oauth2.service_account.Credentials.from_service_account_file')
+        fake_creds = MagicMock()
+        mock_from_file.return_value = fake_creds
+
+        client = GoogleBigQueryClient(project=project, credentials=fake_path)
+
+        mock_from_file.assert_called_once_with(fake_path)
+        mock_bq_client_class.assert_called_once_with(project=project, credentials=fake_creds)
+        assert client.client == mock_bq_client_class.return_value
+
+    def test_init_with_existing_service_account_credentials(self, mocker, mock_service_account_credentials):
+        project = 'fake-project'
+        mock_bq_client_class = mocker.patch('bigquery_exporter.clients.google_client.bigquery.Client')
+
+        client = GoogleBigQueryClient(project=project, credentials=mock_service_account_credentials)
+
+        mock_bq_client_class.assert_called_once_with(project=project, credentials=mock_service_account_credentials)
+        assert client.client == mock_bq_client_class.return_value
+
+    def test_init_raises_valueerror_on_unsupported_credentials_type(self):
+        with pytest.raises(ValueError) as exc_info:
+            GoogleBigQueryClient(
+                project='fake-project',
+                # Invalid credentials type
+                credentials={'fake': 'service_account'}
+            )
+
+        assert 'Unsupported credentials type: "dict"' in str(exc_info.value)
+
+    def test_init_raises_bigqueryexporteriniterror_on_google_api_error(self, mocker):
+        mock_bq_client_class = mocker.patch('bigquery_exporter.clients.google_client.bigquery.Client')
+        mock_bq_client_class.side_effect = GoogleAPICallError('Project not found')
+
+        with pytest.raises(BigQueryExporterInitError) as exc_info:
+            GoogleBigQueryClient(project='nonexistent-project')
+
+        assert 'Project not found' in str(exc_info.value)
+
+    def test_get_table_delegates_to_client(self, mocker):
+        mock_bq_client = MagicMock()
+        mocker.patch('bigquery_exporter.clients.google_client.bigquery.Client', return_value=mock_bq_client)
+        client = GoogleBigQueryClient()
+        fake_table_id = 'project.dataset.table'
+
+        result = client.get_table(fake_table_id)
+
+        mock_bq_client.get_table.assert_called_once_with(fake_table_id)
+        assert result == mock_bq_client.get_table.return_value
+
+    def test_insert_rows_delegates_to_client(self, mocker, fake_table):
+        mock_bq_client = MagicMock()
+        mocker.patch('bigquery_exporter.clients.google_client.bigquery.Client', return_value=mock_bq_client)
+        client = GoogleBigQueryClient()
+        rows = [{'id': 1, 'value': 'test'}]
+
+        client.insert_rows(fake_table, rows)
+
+        mock_bq_client.insert_rows.assert_called_once_with(
+            fake_table,
+            rows,
+            retry=None
+        )
+
+    def test_query_delegates_to_client(self, mocker):
+        mock_bq_client = MagicMock()
+        mocker.patch('bigquery_exporter.clients.google_client.bigquery.Client', return_value=mock_bq_client)
+        client = GoogleBigQueryClient()
+        sql = 'SELECT * FROM `project.dataset.table` LIMIT 10'
+
+        job = client.query(sql)
+
+        mock_bq_client.query.assert_called_once_with(sql)
+        assert job == mock_bq_client.query.return_value


### PR DESCRIPTION
* Adds support for passing `google.oauth2.service_account.Credentials` object directly as `credentials` when initializing `BigQueryExporter`/`GoogleBigQueryClient`. 
* Adds unit tests for `GoogleBigQueryClient`.